### PR TITLE
Fixes variable name typo and exports a couple of convenient methods.

### DIFF
--- a/environments/atlas/methods/initialize.jl
+++ b/environments/atlas/methods/initialize.jl
@@ -223,11 +223,11 @@ function initialize_atlas!(mechanism::Mechanism;
     return nothing
 end
 
-function initialize_atlas_stance!(mechanism::Mechanism;
+function initialize_atlas_stance!(mech::Mechanism;
     body_position=[0.0, 0.0, 0.2],
     body_orientation=[0.0, 0.0, 0.0],
-    link_linear_velocity=[zeros(3)  for i=1:length(mechanism.bodies)],
-    link_angular_velocity=[zeros(3) for i=1:length(mechanism.bodies)],
+    link_linear_velocity=[zeros(3)  for i=1:length(mech.bodies)],
+    link_angular_velocity=[zeros(3) for i=1:length(mech.bodies)],
     hip_orientation=0.0, 
     knee_orienation=0.0) where T
     
@@ -278,7 +278,7 @@ function initialize_atlas_stance!(mechanism::Mechanism;
         nothing
     end
 
-    zero_velocity!(mechanism)
+    zero_velocity!(mech)
 
     return nothing
 end

--- a/src/Dojo.jl
+++ b/src/Dojo.jl
@@ -191,7 +191,8 @@ export
     get_contact,
     get_sdf,
     contact_location,
-    damper_impulses
+    damper_impulses,
+    contact_constraint
 
 # Inputs
 export

--- a/src/Dojo.jl
+++ b/src/Dojo.jl
@@ -205,7 +205,8 @@ export
     Mechanism,
     get_mechanism,
     initialize!,
-    set_floating_base
+    set_floating_base,
+    zero_velocity!
 
 # Maximal
 export


### PR DESCRIPTION
@thowell 
- Fixed a variable name error in `environments/atlas/methods/initialize.jl`. 

- Exported a couple of functions in `src/Dojo.jl` that make defining custom mechanisms outside the Dojo.jl package  less verbose.