### PR TITLE
Add Symbolics to the dependecies of examples

### DIFF
--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -7,10 +7,11 @@ JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 PGFPlots = "3b7a836e-365b-5785-a47d-02c71176b4aa"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-Folds = "0.2"
 FiniteDiff = "2.11.0"
+Folds = "0.2"
 IterativeLQR = "0.1.1"
 JLD2 = "0.4.21"
 Literate = "2.13.0"


### PR DESCRIPTION
It seems the dependency on Symbolics is not declared anywhere.