### PR TITLE
Updated the gain and simulation time

### DIFF
--- a/docs/src/define_controller.md
+++ b/docs/src/define_controller.md
@@ -33,7 +33,7 @@ function controller!(mechanism, t)
     x = get_minimal_state(mechanism)
 
     ## Gains
-    K = [5.0 0.5] * 0.1
+    K = [75.0 0.5] * 0.1
 
     # Control inputs
     u =  -K * (x - x_goal)
@@ -50,7 +50,7 @@ initialize!(mechanism, :pendulum,
 
 We simulate the system for 2 seconds using the `controller!`.
 ```julia
-storage = simulate!(mechanism, 2.0, controller!,
+storage = simulate!(mechanism, 20.0, controller!,
     record=true,
     verbose=true);
 ```


### PR DESCRIPTION
The P gain and the simulation time needed to be increased to match the desired performance. 

**NOTE:** The simulations outputs NAN values for mu
```
storage = simulate!(mechanism, 20.0, controller!,
    record=true,
    verbose=true);
```
```
n    bvio    rvio     α       μ     |res|∞   |Δ|∞
–––––––––––––––––––––––––––––––––––––––––––––––––
1    0e+0    1e-1    1e+0    0e+0    1e-1    1e-1
2    0e+0    1e-11    1e+0    NaN     1e-11    1e-11
```
