### PR TITLE
typo fix in utilities.jl

### DIFF
--- a/src/contacts/utilities.jl
+++ b/src/contacts/utilities.jl
@@ -50,7 +50,7 @@ function contact_location(mechanism::Mechanism, contact::ContactConstraint)
 end
 
 function contact_location(mechanism::Mechanism)
-    return [contact_location(mech, contact) for contact in mechanism.contacts]
+    return [contact_location(mechanism, contact) for contact in mechanism.contacts]
 end
 
 #="""


### PR DESCRIPTION
typo : `mech` should be `mechanism` in `contact_location` function.